### PR TITLE
Explained an assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Or:
 - Create a keystore file `thekeystore` under `/etc/cas` on Linux. Use `c:/etc/cas` on Windows.
 - Use the password `changeit` for both the keystore and the key/certificate entries.
 - Ensure the keystore is loaded up with keys and certificates of the server.
+    - Add the following to ./etc/cas/config/cas.properties
+    ```
+    server.ssl.keyStore=file:/etc/cas/thekeystore
+    server.ssl.keyStorePassword=changeit
+    server.ssl.keyPassword=changeit
+    ```
 
 On a successful deployment via the following methods, CAS will be available at:
 


### PR DESCRIPTION
"Ensure the keystore is loaded up with keys and certificates of the server" 

I have no idea how to do that. To be fair I didn't know how to make a keystore either, but I could google that pretty easily. But when CAS's own documentation doesn't explain it self there isn't much one can do. Took my an afternoon before I figured out what I was supposed to do to get CAS to recognize the keystore's location. I was coming to this from CAS 3 where that is managed by tomcat, so I was really confused. 

Figured it might help others to have that spelled out as well.