### PR TITLE
Add CAS Command Line Shell to Gradle Overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,13 @@ to examine dependencies, configuration files and such that are merged as part of
 ./gradlew[.bat] explodeWar
 ```
 
+
+## Command Line Shell
+
+Invokes the CAS Command Line Shell. Use -q to quiet Gradle output. To pass arguments, use '-Pcargs=arg1,arg2,arg3,...'.
+For a list of commands either use no arguments or use -h. To enter the interactive shell use -sh.
+
+```bash
+./gradlew[.bat] -q command
+```
+

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ used as a starting template for local CAS gradle war overlays.
 
 ## Versions
 
-* CAS 5.1.x
+* CAS 5.2.0-RC2
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ used as a starting template for local CAS gradle war overlays.
 
 ## Versions
 
-* CAS 5.2.0-RC2
+* CAS `5.2.x`
 
 ## Requirements
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,3 +33,23 @@ task generateKeys {
     }
   }
 }
+
+task command (type: JavaExec) {
+  group = 'CAS'
+  description = "Invokes the CAS Command Line Shell. Use -q to quiet Gradle output. To pass arguments, use '-Pcargs=arg1,arg2,arg3,...'"
+  main='-jar'
+  standardInput = System.in
+  if (project.hasProperty("cas.version")) {
+      def casVersion = project.getProperty("cas.version")
+      def commandFilePath = System.getProperty("user.dir") + File.separator + "cas" + File.separator + "build" + File.separator + "cas-server-support-shell-${casVersion}.jar"
+      def commandFile = new File(commandFilePath)
+      if (!commandFile.exists()) {
+          new URL("http://repo1.maven.org/maven2/org/apereo/cas/cas-server-support-shell/${casVersion}/cas-server-support-shell-${casVersion}.jar").withInputStream{ i -> commandFile.withOutputStream{ it << i }}
+      }
+      def args2 = [commandFile]
+      if (project.hasProperty('cargs')) {
+          args2.addAll(cargs.trim().split(','))
+      }
+      args = args2
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-cas.version=5.1.2
+cas.version=5.2.0-RC2
 
 ##
 # Only modify below this line if you know what you're doing!

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ cas.version=5.2.0-RC2
 gradle.version=3.5
 sourceCompatibility=1.8
 targetCompatibility=1.8
-springboot.version=1.5.3.RELEASE
+springboot.version=1.5.6.RELEASE
 
 # For debug, increase speed when executing gradle many times
 # Daemon will keep running a daemon for 3h hours on each gradle run, improves speed


### PR DESCRIPTION
Adds the ability to run the command line shell to the gradle overlay. There are two ways to approach this (bat/cmd) executing java or gradle exec java. This takes the latter approach as both were similar in performance. No Linux issues were found. Windows users may experience issues with output or more often input. From research this seems to be inherent to the JVM installed and Windows version. These issues resulted even in running the java -jar * command shell from Powershell or Cmd natively.  