### PR TITLE
Fix typo on log function in gradle

### DIFF
--- a/cas/build.gradle
+++ b/cas/build.gradle
@@ -72,7 +72,7 @@ task run(group: "build", description: "Run the CAS web application in embedded c
             jvmArgs = casRunArgs
             args = ["build/libs/cas.war"]
             
-            log.info "Started ${commandLine}"
+            logger.info "Started ${commandLine}"
         }
     }
 }
@@ -87,7 +87,7 @@ task debug(group: "build", description: "Debug the CAS web application in embedd
             jvmArgs = casDebugArgs
             args = ["build/libs/cas.war"]
             
-            log.info "Started ${commandLine}"
+            logger.info "Started ${commandLine}"
         }
     }
 }


### PR DESCRIPTION
Fix issue when running command line "./gradlew run"

``` gradle
* Where:
Build file '/home/ubuntu/workspace/cas/build.gradle' line: 75

* What went wrong:
Execution failed for task ':cas:run'.
> Could not get unknown property 'log' for object of type org.gradle.process.internal.DefaultJavaExecAction_Decorated.
```